### PR TITLE
Oneapi/fix lark integrate

### DIFF
--- a/common/config/config.go
+++ b/common/config/config.go
@@ -156,7 +156,7 @@ var (
 	DownloadRateLimitNum            = 10
 	DownloadRateLimitDuration int64 = 60
 
-	CriticalRateLimitNum            = 20
+	CriticalRateLimitNum            = env.Int("CRITICAL_RATE_LIMIT", 20)
 	CriticalRateLimitDuration int64 = 20 * 60
 )
 

--- a/controller/auth/lark.go
+++ b/controller/auth/lark.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strconv"
 	"time"
+	"strings"
 
 	"github.com/gin-contrib/sessions"
 	"github.com/gin-gonic/gin"
@@ -24,6 +25,7 @@ type LarkOAuthResponse struct {
 type LarkUser struct {
 	Name   string `json:"name"`
 	OpenID string `json:"open_id"`
+	Email  string `json:"email"`
 }
 
 func getLarkUserInfoByCode(code string) (*LarkUser, error) {
@@ -118,7 +120,12 @@ func LarkOAuth(c *gin.Context) {
 		}
 	} else {
 		if config.RegisterEnabled {
-			user.Username = "lark_" + strconv.Itoa(model.GetMaxUserId()+1)
+			parts := strings.Split(larkUser.Email, "@")
+			if len(parts) > 1 {
+				user.Username = parts[0]
+			} else {
+				user.Username = "lark_" + strconv.Itoa(model.GetMaxUserId()+1)
+			}
 			if larkUser.Name != "" {
 				user.DisplayName = larkUser.Name
 			} else {

--- a/model/user.go
+++ b/model/user.go
@@ -32,7 +32,7 @@ const (
 // Otherwise, the sensitive information will be saved on local storage in plain text!
 type User struct {
 	Id               int    `json:"id"`
-	Username         string `json:"username" gorm:"unique;index" validate:"max=12"`
+	Username         string `json:"username" gorm:"unique;index" validate:"max=30"`
 	Password         string `json:"password" gorm:"not null;" validate:"min=8,max=20"`
 	DisplayName      string `json:"display_name" gorm:"index" validate:"max=20"`
 	Role             int    `json:"role" gorm:"type:int;default:1"`   // admin, util


### PR DESCRIPTION

- Some Lark users have usernames that are too long, exceeding the 12-character limit.
- When administrators create users in bulk, the frequency limit of the login API causes the bulk creation process to be very slow.
- When Lark users register, usernames like "lark_1" and "lark_2" are generated, which is not user-friendly for management.