### PR TITLE
feature: Limit the speed of channels

### DIFF
--- a/common/config/config.go
+++ b/common/config/config.go
@@ -150,6 +150,9 @@ var (
 	GlobalWebRateLimitNum            = env.Int("GLOBAL_WEB_RATE_LIMIT", 240)
 	GlobalWebRateLimitDuration int64 = 3 * 60
 
+	GlobalRelayRateLimitNum            = env.Int("GLOBAL_RELAY_RATE_LIMIT", 480)
+	GlobalRelayRateLimitDuration int64 = 3 * 60
+
 	UploadRateLimitNum            = 10
 	UploadRateLimitDuration int64 = 60
 

--- a/middleware/auth.go
+++ b/middleware/auth.go
@@ -95,11 +95,8 @@ func RootAuth() func(c *gin.Context) {
 func TokenAuth() func(c *gin.Context) {
 	return func(c *gin.Context) {
 		ctx := c.Request.Context()
-		key := c.Request.Header.Get("Authorization")
-		key = strings.TrimPrefix(key, "Bearer ")
-		key = strings.TrimPrefix(strings.TrimPrefix(key, "sk-"), "laisky-")
-		parts := strings.Split(key, "-")
-		key = parts[0]
+		parts := GetTokenKeyParts(c)
+		key := parts[0]
 		token, err := model.ValidateUserToken(key)
 		if err != nil {
 			AbortWithError(c, http.StatusUnauthorized, err)

--- a/middleware/utils.go
+++ b/middleware/utils.go
@@ -76,3 +76,10 @@ func isModelInList(modelName string, models string) bool {
 	}
 	return false
 }
+
+func GetTokenKeyParts(c *gin.Context) []string {
+	key := c.Request.Header.Get("Authorization")
+	key = strings.TrimPrefix(key, "Bearer ")
+	key = strings.TrimPrefix(strings.TrimPrefix(key, "sk-"), "laisky-")
+	return strings.Split(key, "-")
+}

--- a/router/relay.go
+++ b/router/relay.go
@@ -19,6 +19,7 @@ func SetRelayRouter(router *gin.Engine) {
 	}
 	relayV1Router := router.Group("/v1")
 	relayV1Router.Use(middleware.RelayPanicRecover(), middleware.TokenAuth(), middleware.Distribute())
+	relayV1Router.Use(middleware.GlobalRelayRateLimit())
 	{
 		relayV1Router.Any("/oneapi/proxy/:channelid/*target", controller.Relay)
 		relayV1Router.POST("/completions", controller.Relay)


### PR DESCRIPTION
Currently, rate limiting is only supported at the system API and web front-end levels. We aim to enhance this by extending support to token-level granularity.